### PR TITLE
Add mastodon_bot.py with edits to README.md for Mastdon users

### DIFF
--- a/mastodon_bot.py
+++ b/mastodon_bot.py
@@ -1,0 +1,84 @@
+# EVERY FRAME IN ORDER BOT FOR TWITTER
+# Original twitter bot by Pigeonburger, 2022
+# https://github.com/pigeonburger
+#
+# Modified Mastodon bot by cfultz, 2023
+# https://github.com/cfultz
+#
+import sqlite3 as db
+import os
+from mastodon import Mastodon
+
+# Set up Mastodon
+mastodon = Mastodon(
+    access_token = 'token.secret',
+    api_base_url = 'https://botsin.space'
+)
+
+
+# Connect to the SQLite database that was created in setupbot.py
+connection = db.connect("framebot.db")
+cursor = connection.cursor()
+
+# Enter the name of the show you're posting frames for here:
+show_name = ""
+
+# Put the number of frames the bot should post each time this script is run here.
+iters = 5
+
+while iters > 0:
+    # Get the current season & episode the bot is currently on.
+    current_ep = cursor.execute("SELECT current_episode FROM bot").fetchone()[0]
+    
+    # Get season and episode number
+    ep_season, ep_num = current_ep.split('x')
+
+    # Get the total frames from that episode.
+    total_frames = cursor.execute(f"SELECT frames FROM show WHERE ep = \"{current_ep}\"").fetchone()[0]
+
+    # Get the number of the last frame that was uploaded, then add one to that number to get the number of the next frame to post.
+    next_frame = cursor.execute("SELECT last_frame FROM bot").fetchone()[0] + 1
+
+    # If the next_frame number is bigger than the number of total frames in the episode, then the current_episode db value needs to be updated.
+    if next_frame > total_frames:
+        next_ep = str(int(ep_num)+1).zfill(2)
+
+        # If another episode in the same season is found, update the database to reflect that.
+        if os.path.isfile(f"./frames/S{ep_season}/{next_ep}x1.jpg"):
+            cursor.execute(f'UPDATE bot SET current_episode = "{ep_season}x{next_ep}"')
+            cursor.execute(f'UPDATE bot SET last_frame = 0')
+            connection.commit()
+            continue # var iters does not change, loop again
+            
+        # Otherwise, we need to go to a new season.
+        
+        else:
+            next_season = str(int(ep_season) + 1).zfill(2)
+
+            cursor.execute(f'UPDATE bot SET current_episode = "{next_season}x01"')
+            cursor.execute(f'UPDATE bot SET last_frame = 0')
+            connection.commit()
+            continue # var iters does not change, loop again
+
+        # Need to add a check here to see if the entire series is finished or not....
+
+    # Get the file path for the next frame to upload.
+    frame_path = f"./frames/S{ep_season}/{ep_num}x{next_frame}.jpg"
+
+    # The message to attach to the toot
+    msg = {show_name} - Season {ep_season} Episode {ep_num} - Frame {next_frame} of {total_frames}
+
+    # Send the toot
+    media = mastodon.media_post(frame_path)
+
+    mastodon.status_post(msg,media_ids=media)
+
+    # Update the database to reflect the most recently uploaded frame.
+    cursor.execute(f"UPDATE bot SET last_frame = {next_frame}")
+    connection.commit()
+
+    # That's one complete loop of the total number to upload finished.
+    iters -= 1
+    
+# Automatically exit the script when finished.
+


### PR DESCRIPTION
Hello pigeonburger! First, love the bot and have followed it since you were posting Season 2. 

I have moved (mostly) away from Twitter to my own Mastodon instance so I modified the bot.py into mastodon_bot.py to be able to utilize it on for my personal bot [@amityisland](https://cfultz.com/@amityisland) which is posting every frame from the movie 'Jaws'. This should take about a month to complete. 

At any rate, the attached pull request contains only the bot. In order for users to interact with this bot, they will need to install `Mastodon.py` from pip, have an access token from whichever instance they are hosting their bot on. This can be hardcoded into the bot much like the twitter API stuff at the line "token.secret" or I just store it direclty in a file called "token.secret" in the same directory for a bit of obsecurity.

I have a full repository for the bot itself located [here](https://github.com/cfultz/MastodonFrameBot/) if you'd like to see the modifications to the README.md file as well.

Thanks again for the consideration of adding support for Mastodon users!

 - @cfultz (and on [Mastodon](https://cfultz.com/@cfultz))